### PR TITLE
iOSのペイロード内のBadgeをポインタに変更

### DIFF
--- a/cmd/gaurun_recover/gaurun_recover.go
+++ b/cmd/gaurun_recover/gaurun_recover.go
@@ -189,7 +189,7 @@ func main() {
 			TimeToLive:       logPush.TimeToLive,
 			Title:            logPush.Title,
 			Subtitle:         logPush.Subtitle,
-			Badge:            logPush.Badge,
+			Badge:            &logPush.Badge,
 			Category:         logPush.Category,
 			Sound:            logPush.Sound,
 			ContentAvailable: logPush.ContentAvailable,

--- a/gaurun/apns_http2.go
+++ b/gaurun/apns_http2.go
@@ -68,9 +68,13 @@ func NewApnsServiceHttp2(client *http.Client) *push.Service {
 }
 
 func NewApnsPayloadHttp2(req *RequestGaurunNotification) map[string]interface{} {
+	b := badge.Preserve
+	if req.Badge != nil {
+		b = badge.New(uint(*req.Badge))
+	}
 	p := payload.APS{
 		Alert:            payload.Alert{Title: req.Title, Body: req.Message, Subtitle: req.Subtitle},
-		Badge:            badge.New(uint(req.Badge)),
+		Badge:            b,
 		Category:         req.Category,
 		Sound:            req.Sound,
 		ContentAvailable: req.ContentAvailable,

--- a/gaurun/log.go
+++ b/gaurun/log.go
@@ -159,8 +159,8 @@ func LogPush(id uint64, status, token string, ptime float64, req RequestGaurunNo
 		subtitle = zap.String("subtitle", req.Subtitle)
 	}
 	badge := zap.Skip()
-	if req.Badge != 0 {
-		badge = zap.Int("badge", req.Badge)
+	if req.Badge != nil {
+		badge = zap.Int("badge", *req.Badge)
 	}
 	category := zap.Skip()
 	if req.Category != "" {

--- a/gaurun/log_test.go
+++ b/gaurun/log_test.go
@@ -28,9 +28,10 @@ func BenchmarkLogPushIOSOmitempty(b *testing.B) {
 }
 
 func BenchmarkLogPushIOSFull(b *testing.B) {
+	badge := 1
 	req := RequestGaurunNotification{
 		Platform:         PlatFormIos,
-		Badge:            1,
+		Badge:            &badge,
 		Sound:            "foo",
 		ContentAvailable: true,
 		Expiry:           100,

--- a/gaurun/notification.go
+++ b/gaurun/notification.go
@@ -31,7 +31,7 @@ type RequestGaurunNotification struct {
 	// iOS
 	Title            string       `json:"title,omitempty"`
 	Subtitle         string       `json:"subtitle,omitempty"`
-	Badge            int          `json:"badge,omitempty"`
+	Badge            *int         `json:"badge,omitempty"`
 	Category         string       `json:"category,omitempty"`
 	Sound            string       `json:"sound,omitempty"`
 	ContentAvailable bool         `json:"content_available,omitempty"`


### PR DESCRIPTION
## やったこと
PUSH通知にバッヂ数が設定されていない場合はiOS側でアプリバッヂを保持できるようにした

## 背景
メッセージボックスの未読件数をアプリバッヂに表示する対応に関連してます。
https://everytv.atlassian.net/wiki/spaces/DK/pages/718143609/20200403+BOX+ph2
現状だと未読件数をアプリバッヂに表示できても他のPUSH通知によってアプリバッヂが消されてしまうのでこの対応が必要になります。

## 確認したこと
ローカルでgaurunを起動し、curlを実行して修正前と修正後で動作が期待どおりであることを確認
iOSの端末のみで確認
### 修正前
- badgeに1を設定してPUSH通知を送ると、アプリバッヂが付く
- badgeを設定せずPUSH通知を送ると、アプリバッヂが消える

### 修正後
- badgeに1を設定してPUSH通知を送ると、アプリバッヂが付く
- badgeを設定せずPUSH通知を送ると、アプリバッヂは保持される
- badgeに0を設定してPUSH通知を送ると、アプリバッヂが消える